### PR TITLE
Add cargo-audit to available tools

### DIFF
--- a/1.38.0/buster/Dockerfile
+++ b/1.38.0/buster/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    cargo install cargo-audit; \
     rustup --version; \
     cargo --version; \
     rustc --version;


### PR DESCRIPTION
The idea is to give the necessary tools to people.
If you like the idea I would modify the other Dockerfiles as well.

Alternatively, this could become a new tag like `audit` or `extended` or similar.

Cheers,
Stefan