### PR TITLE
Add debian powerpc64le images

### DIFF
--- a/1.60.0/bullseye/Dockerfile
+++ b/1.60.0/bullseye/Dockerfile
@@ -12,6 +12,7 @@ RUN set -eux; \
         armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='67777ac3bc17277102f2ed73fd5f14c51f4ca5963adadf7f174adf4ebc38747b' ;; \
         arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1' ;; \
         i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e50d1deb99048bc5782a0200aa33e4eea70747d49dffdc9d06812fd22a372515' ;; \
+        ppc64el) rustArch='powerpc64le-unknown-linux-gnu'; rustupSha256='29fc4200c2ea1c05d5db81567941911c1b826814704b6216f0bc86963f414e64' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init"; \

--- a/1.60.0/bullseye/slim/Dockerfile
+++ b/1.60.0/bullseye/slim/Dockerfile
@@ -19,6 +19,7 @@ RUN set -eux; \
         armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='67777ac3bc17277102f2ed73fd5f14c51f4ca5963adadf7f174adf4ebc38747b' ;; \
         arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1' ;; \
         i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e50d1deb99048bc5782a0200aa33e4eea70747d49dffdc9d06812fd22a372515' ;; \
+        ppc64el) rustArch='powerpc64le-unknown-linux-gnu'; rustupSha256='29fc4200c2ea1c05d5db81567941911c1b826814704b6216f0bc86963f414e64' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init"; \

--- a/1.60.0/buster/Dockerfile
+++ b/1.60.0/buster/Dockerfile
@@ -12,6 +12,7 @@ RUN set -eux; \
         armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='67777ac3bc17277102f2ed73fd5f14c51f4ca5963adadf7f174adf4ebc38747b' ;; \
         arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1' ;; \
         i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e50d1deb99048bc5782a0200aa33e4eea70747d49dffdc9d06812fd22a372515' ;; \
+        ppc64el) rustArch='powerpc64le-unknown-linux-gnu'; rustupSha256='29fc4200c2ea1c05d5db81567941911c1b826814704b6216f0bc86963f414e64' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init"; \

--- a/1.60.0/buster/slim/Dockerfile
+++ b/1.60.0/buster/slim/Dockerfile
@@ -19,6 +19,7 @@ RUN set -eux; \
         armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='67777ac3bc17277102f2ed73fd5f14c51f4ca5963adadf7f174adf4ebc38747b' ;; \
         arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1' ;; \
         i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e50d1deb99048bc5782a0200aa33e4eea70747d49dffdc9d06812fd22a372515' ;; \
+        ppc64el) rustArch='powerpc64le-unknown-linux-gnu'; rustupSha256='29fc4200c2ea1c05d5db81567941911c1b826814704b6216f0bc86963f414e64' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init"; \

--- a/x.py
+++ b/x.py
@@ -16,6 +16,7 @@ debian_arches = [
     DebianArch("arm32v7", "armhf", "armv7-unknown-linux-gnueabihf"),
     DebianArch("arm64v8", "arm64", "aarch64-unknown-linux-gnu"),
     DebianArch("i386", "i386", "i686-unknown-linux-gnu"),
+    DebianArch("ppc64le", "ppc64el", "powerpc64le-unknown-linux-gnu"),
 ]
 
 debian_variants = [


### PR DESCRIPTION
Adds powerpc64le-support to debian-based images.

Alpine-images are based on musl, and therefore not supported by rust on ppc64le: https://doc.rust-lang.org/rustc/platform-support.html

This partly solves issue #54 