### PR TITLE
Add Alpine 3.16 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   - VERSION=1.61.0 VARIANT=buster/slim
   - VERSION=1.61.0 VARIANT=bullseye
   - VERSION=1.61.0 VARIANT=bullseye/slim
-  - VERSION=1.61.0 VARIANT=alpine3.14
   - VERSION=1.61.0 VARIANT=alpine3.15
+  - VERSION=1.61.0 VARIANT=alpine3.16
 #VERSIONS
 
 install:

--- a/1.61.0/alpine3.16/Dockerfile
+++ b/1.61.0/alpine3.16/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.16
 
 RUN apk add --no-cache \
         ca-certificates \

--- a/x.py
+++ b/x.py
@@ -33,11 +33,11 @@ alpine_arches = [
 ]
 
 alpine_versions = [
-    "3.14",
     "3.15",
+    "3.16",
 ]
 
-default_alpine_version = "3.15"
+default_alpine_version = "3.16"
 
 def rustup_hash(arch):
     url = f"https://static.rust-lang.org/rustup/archive/{rustup_version}/{arch}/rustup-init.sha256"


### PR DESCRIPTION
This patch adds support for the new 3.16 Alpine version to the Rust
docker alpine image. Following the [support policy] suggested in the
3.15 PR, the 3.14 version is removed.

[support policy]: https://github.com/rust-lang/docker-rust/pull/95#discussion_r779944861