### PR TITLE
Bump to 1.62.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ services: docker
 
 env:
 #VERSIONS
-  - VERSION=1.61.0 VARIANT=buster
-  - VERSION=1.61.0 VARIANT=buster/slim
-  - VERSION=1.61.0 VARIANT=bullseye
-  - VERSION=1.61.0 VARIANT=bullseye/slim
-  - VERSION=1.61.0 VARIANT=alpine3.15
-  - VERSION=1.61.0 VARIANT=alpine3.16
+  - VERSION=1.62.0 VARIANT=buster
+  - VERSION=1.62.0 VARIANT=buster/slim
+  - VERSION=1.62.0 VARIANT=bullseye
+  - VERSION=1.62.0 VARIANT=bullseye/slim
+  - VERSION=1.62.0 VARIANT=alpine3.15
+  - VERSION=1.62.0 VARIANT=alpine3.16
 #VERSIONS
 
 install:

--- a/1.62.0/alpine3.15/Dockerfile
+++ b/1.62.0/alpine3.15/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.15
 
 RUN apk add --no-cache \
         ca-certificates \
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.61.0
+    RUST_VERSION=1.62.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.62.0/alpine3.16/Dockerfile
+++ b/1.62.0/alpine3.16/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN apk add --no-cache \
         ca-certificates \
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.61.0
+    RUST_VERSION=1.62.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.62.0/bullseye/Dockerfile
+++ b/1.62.0/bullseye/Dockerfile
@@ -1,9 +1,9 @@
-FROM buildpack-deps:buster
+FROM buildpack-deps:bullseye
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.61.0
+    RUST_VERSION=1.62.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.62.0/bullseye/slim/Dockerfile
+++ b/1.62.0/bullseye/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.61.0
+    RUST_VERSION=1.62.0
 
 RUN set -eux; \
     apt-get update; \

--- a/1.62.0/buster/Dockerfile
+++ b/1.62.0/buster/Dockerfile
@@ -1,9 +1,9 @@
-FROM buildpack-deps:bullseye
+FROM buildpack-deps:buster
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.61.0
+    RUST_VERSION=1.62.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.62.0/buster/slim/Dockerfile
+++ b/1.62.0/buster/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.61.0
+    RUST_VERSION=1.62.0
 
 RUN set -eux; \
     apt-get update; \

--- a/x.py
+++ b/x.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-rust_version = "1.61.0"
+rust_version = "1.62.0"
 rustup_version = "1.24.3"
 
 DebianArch = namedtuple("DebianArch", ["bashbrew", "dpkg", "rust"])


### PR DESCRIPTION
This bumps the version to 1.62.0

Release: https://github.com/rust-lang/rust/releases/tag/1.62.0