### PR TITLE
Bump to 1.62.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ services: docker
 
 env:
 #VERSIONS
-  - VERSION=1.62.0 VARIANT=buster
-  - VERSION=1.62.0 VARIANT=buster/slim
-  - VERSION=1.62.0 VARIANT=bullseye
-  - VERSION=1.62.0 VARIANT=bullseye/slim
-  - VERSION=1.62.0 VARIANT=alpine3.15
-  - VERSION=1.62.0 VARIANT=alpine3.16
+  - VERSION=1.62.1 VARIANT=buster
+  - VERSION=1.62.1 VARIANT=buster/slim
+  - VERSION=1.62.1 VARIANT=bullseye
+  - VERSION=1.62.1 VARIANT=bullseye/slim
+  - VERSION=1.62.1 VARIANT=alpine3.15
+  - VERSION=1.62.1 VARIANT=alpine3.16
 #VERSIONS
 
 install:

--- a/1.62.1/1.62.0/alpine3.15/Dockerfile
+++ b/1.62.1/1.62.0/alpine3.15/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.62.0
+    RUST_VERSION=1.62.1
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.62.1/1.62.0/alpine3.16/Dockerfile
+++ b/1.62.1/1.62.0/alpine3.16/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.62.0
+    RUST_VERSION=1.62.1
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.62.1/1.62.0/bullseye/Dockerfile
+++ b/1.62.1/1.62.0/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bullseye
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.62.0
+    RUST_VERSION=1.62.1
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.62.1/1.62.0/bullseye/slim/Dockerfile
+++ b/1.62.1/1.62.0/bullseye/slim/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.62.0
+    RUST_VERSION=1.62.1
 
 RUN set -eux; \
     apt-get update; \

--- a/1.62.1/1.62.0/buster/Dockerfile
+++ b/1.62.1/1.62.0/buster/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:buster
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.62.0
+    RUST_VERSION=1.62.1
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.62.1/1.62.0/buster/slim/Dockerfile
+++ b/1.62.1/1.62.0/buster/slim/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.62.0
+    RUST_VERSION=1.62.1
 
 RUN set -eux; \
     apt-get update; \

--- a/x.py
+++ b/x.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-rust_version = "1.62.0"
+rust_version = "1.62.1"
 rustup_version = "1.24.3"
 
 DebianArch = namedtuple("DebianArch", ["bashbrew", "dpkg", "rust"])


### PR DESCRIPTION
This bumps the version to 1.62.1

Release: https://github.com/rust-lang/rust/releases/tag/1.62.1

Blog: https://blog.rust-lang.org/2022/07/19/Rust-1.62.1.html