### PR TITLE
add edge alpine version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - VERSION=1.63.0 VARIANT=bullseye/slim
   - VERSION=1.63.0 VARIANT=alpine3.15
   - VERSION=1.63.0 VARIANT=alpine3.16
+  - VERSION=1.63.0 VARIANT=alpineedge
 #VERSIONS
 
 install:

--- a/1.63.0/alpineedge/Dockerfile
+++ b/1.63.0/alpineedge/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:edge
+
+RUN apk add --no-cache \
+        ca-certificates \
+        gcc
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.63.0
+
+RUN set -eux; \
+    apkArch="$(apk --print-arch)"; \
+    case "$apkArch" in \
+        x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='95427cb0592e32ed39c8bd522fe2a40a746ba07afb8149f91e936cddb4d6eeac' ;; \
+        aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='7855404cdc50c20040c743800c947b6f452490d47f8590a4a83bc6f75d1d8eda' ;; \
+        *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.25.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;

--- a/x.py
+++ b/x.py
@@ -35,6 +35,7 @@ alpine_arches = [
 alpine_versions = [
     "3.15",
     "3.16",
+    "edge",
 ]
 
 default_alpine_version = "3.16"


### PR DESCRIPTION
Some packages of latest version like [openssl 3.0.5-r2](https://pkgs.alpinelinux.org/packages?name=openssl&branch=edge&repo=&arch=&maintainer=) are provided in edge version. So it's useful to build an edge version of alpine rust docker image.