### PR TITLE
bump to rust version 1.65.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ services: docker
 
 env:
 #VERSIONS
-  - VERSION=1.64.0 VARIANT=buster
-  - VERSION=1.64.0 VARIANT=buster/slim
-  - VERSION=1.64.0 VARIANT=bullseye
-  - VERSION=1.64.0 VARIANT=bullseye/slim
-  - VERSION=1.64.0 VARIANT=alpine3.15
-  - VERSION=1.64.0 VARIANT=alpine3.16
+  - VERSION=1.65.0 VARIANT=buster
+  - VERSION=1.65.0 VARIANT=buster/slim
+  - VERSION=1.65.0 VARIANT=bullseye
+  - VERSION=1.65.0 VARIANT=bullseye/slim
+  - VERSION=1.65.0 VARIANT=alpine3.15
+  - VERSION=1.65.0 VARIANT=alpine3.16
 #VERSIONS
 
 install:

--- a/1.65.0/alpine3.15/Dockerfile
+++ b/1.65.0/alpine3.15/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.64.0
+    RUST_VERSION=1.65.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.65.0/alpine3.16/Dockerfile
+++ b/1.65.0/alpine3.16/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.64.0
+    RUST_VERSION=1.65.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.65.0/bullseye/Dockerfile
+++ b/1.65.0/bullseye/Dockerfile
@@ -1,9 +1,9 @@
-FROM buildpack-deps:buster
+FROM buildpack-deps:bullseye
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.64.0
+    RUST_VERSION=1.65.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.65.0/bullseye/slim/Dockerfile
+++ b/1.65.0/bullseye/slim/Dockerfile
@@ -1,11 +1,18 @@
-FROM buildpack-deps:bullseye
+FROM debian:bullseye-slim
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.64.0
+    RUST_VERSION=1.65.0
 
 RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        wget \
+        ; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='5cc9ffd1026e82e7fb2eec2121ad71f4b0f044e88bca39207b3f6b769aaa799c' ;; \
@@ -23,4 +30,8 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version;
+    rustc --version; \
+    apt-get remove -y --auto-remove \
+        wget \
+        ; \
+    rm -rf /var/lib/apt/lists/*;

--- a/1.65.0/buster/Dockerfile
+++ b/1.65.0/buster/Dockerfile
@@ -1,18 +1,11 @@
-FROM debian:bullseye-slim
+FROM buildpack-deps:buster
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.64.0
+    RUST_VERSION=1.65.0
 
 RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        gcc \
-        libc6-dev \
-        wget \
-        ; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='5cc9ffd1026e82e7fb2eec2121ad71f4b0f044e88bca39207b3f6b769aaa799c' ;; \
@@ -30,8 +23,4 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version; \
-    apt-get remove -y --auto-remove \
-        wget \
-        ; \
-    rm -rf /var/lib/apt/lists/*;
+    rustc --version;

--- a/1.65.0/buster/slim/Dockerfile
+++ b/1.65.0/buster/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.64.0
+    RUST_VERSION=1.65.0
 
 RUN set -eux; \
     apt-get update; \

--- a/x.py
+++ b/x.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-rust_version = "1.64.0"
+rust_version = "1.65.0"
 rustup_version = "1.25.1"
 
 DebianArch = namedtuple("DebianArch", ["bashbrew", "dpkg", "rust"])


### PR DESCRIPTION
This bumps the rust version to 1.65.0

Rust Release: https://github.com/rust-lang/rust/releases/tag/1.65.0
Rust Blog: https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html