### PR TITLE
Add tools version of containers

### DIFF
--- a/Dockerfile-tools.template
+++ b/Dockerfile-tools.template
@@ -1,0 +1,3 @@
+FROM rust:%%RUST-IMAGE%%
+
+RUN rustup component add rustfmt clippy llvm-tools-preview 


### PR DESCRIPTION
Adds a tools version of the containers, that adds the following rust components: rustfmt, clippy and llvm-tools-preview. More rust components could be added. But this seams to me the most applicable set for CI.

Al lot of firsts in this pull-request so let me know if I need to change something.

Solves issue: #97