### PR TITLE
bump to rust version 1.66.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ services: docker
 
 env:
 #VERSIONS
-  - VERSION=1.65.0 VARIANT=buster
-  - VERSION=1.65.0 VARIANT=buster/slim
-  - VERSION=1.65.0 VARIANT=bullseye
-  - VERSION=1.65.0 VARIANT=bullseye/slim
-  - VERSION=1.65.0 VARIANT=alpine3.16
-  - VERSION=1.65.0 VARIANT=alpine3.17
+  - VERSION=1.66.0 VARIANT=buster
+  - VERSION=1.66.0 VARIANT=buster/slim
+  - VERSION=1.66.0 VARIANT=bullseye
+  - VERSION=1.66.0 VARIANT=bullseye/slim
+  - VERSION=1.66.0 VARIANT=alpine3.16
+  - VERSION=1.66.0 VARIANT=alpine3.17
 #VERSIONS
 
 install:

--- a/1.66.0/alpine3.16/Dockerfile
+++ b/1.66.0/alpine3.16/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.65.0
+    RUST_VERSION=1.66.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.66.0/alpine3.17/Dockerfile
+++ b/1.66.0/alpine3.17/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.65.0
+    RUST_VERSION=1.66.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.66.0/bullseye/Dockerfile
+++ b/1.66.0/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bullseye
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.65.0
+    RUST_VERSION=1.66.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.66.0/bullseye/slim/Dockerfile
+++ b/1.66.0/bullseye/slim/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.65.0
+    RUST_VERSION=1.66.0
 
 RUN set -eux; \
     apt-get update; \

--- a/1.66.0/buster/Dockerfile
+++ b/1.66.0/buster/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:buster
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.65.0
+    RUST_VERSION=1.66.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.66.0/buster/slim/Dockerfile
+++ b/1.66.0/buster/slim/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.65.0
+    RUST_VERSION=1.66.0
 
 RUN set -eux; \
     apt-get update; \

--- a/x.py
+++ b/x.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-rust_version = "1.65.0"
+rust_version = "1.66.0"
 rustup_version = "1.25.1"
 
 DebianArch = namedtuple("DebianArch", ["bashbrew", "dpkg", "rust"])


### PR DESCRIPTION
This bumps the rust version to 1.65.0

Rust Release: https://github.com/rust-lang/rust/releases/tag/1.66.0
Rust Blog: https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html