### PR TITLE
chore: Bump to rust version 1.71.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ services: docker
 
 env:
 #VERSIONS
-  - VERSION=1.70.0 VARIANT=buster
-  - VERSION=1.70.0 VARIANT=buster/slim
-  - VERSION=1.70.0 VARIANT=bullseye
-  - VERSION=1.70.0 VARIANT=bullseye/slim
-  - VERSION=1.70.0 VARIANT=bookworm
-  - VERSION=1.70.0 VARIANT=bookworm/slim
-  - VERSION=1.70.0 VARIANT=alpine3.17
-  - VERSION=1.70.0 VARIANT=alpine3.18
+  - VERSION=1.71.0 VARIANT=buster
+  - VERSION=1.71.0 VARIANT=buster/slim
+  - VERSION=1.71.0 VARIANT=bullseye
+  - VERSION=1.71.0 VARIANT=bullseye/slim
+  - VERSION=1.71.0 VARIANT=bookworm
+  - VERSION=1.71.0 VARIANT=bookworm/slim
+  - VERSION=1.71.0 VARIANT=alpine3.17
+  - VERSION=1.71.0 VARIANT=alpine3.18
 #VERSIONS
 
 install:

--- a/1.71.0/alpine3.17/Dockerfile
+++ b/1.71.0/alpine3.17/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.70.0
+    RUST_VERSION=1.71.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.71.0/alpine3.18/Dockerfile
+++ b/1.71.0/alpine3.18/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.70.0
+    RUST_VERSION=1.71.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.71.0/bookworm/Dockerfile
+++ b/1.71.0/bookworm/Dockerfile
@@ -1,9 +1,9 @@
-FROM buildpack-deps:buster
+FROM buildpack-deps:bookworm
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.70.0
+    RUST_VERSION=1.71.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.71.0/bookworm/slim/Dockerfile
+++ b/1.71.0/bookworm/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.70.0
+    RUST_VERSION=1.71.0
 
 RUN set -eux; \
     apt-get update; \

--- a/1.71.0/bullseye/Dockerfile
+++ b/1.71.0/bullseye/Dockerfile
@@ -1,18 +1,11 @@
-FROM debian:bullseye-slim
+FROM buildpack-deps:bullseye
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.70.0
+    RUST_VERSION=1.71.0
 
 RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        gcc \
-        libc6-dev \
-        wget \
-        ; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db' ;; \
@@ -30,8 +23,4 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version; \
-    apt-get remove -y --auto-remove \
-        wget \
-        ; \
-    rm -rf /var/lib/apt/lists/*;
+    rustc --version;

--- a/1.71.0/bullseye/slim/Dockerfile
+++ b/1.71.0/bullseye/slim/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.70.0
+    RUST_VERSION=1.71.0
 
 RUN set -eux; \
     apt-get update; \

--- a/1.71.0/buster/Dockerfile
+++ b/1.71.0/buster/Dockerfile
@@ -1,9 +1,9 @@
-FROM buildpack-deps:bullseye
+FROM buildpack-deps:buster
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.70.0
+    RUST_VERSION=1.71.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.71.0/buster/slim/Dockerfile
+++ b/1.71.0/buster/slim/Dockerfile
@@ -1,11 +1,18 @@
-FROM buildpack-deps:bookworm
+FROM debian:buster-slim
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.70.0
+    RUST_VERSION=1.71.0
 
 RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        wget \
+        ; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db' ;; \
@@ -23,4 +30,8 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version;
+    rustc --version; \
+    apt-get remove -y --auto-remove \
+        wget \
+        ; \
+    rm -rf /var/lib/apt/lists/*;

--- a/x.py
+++ b/x.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-rust_version = "1.70.0"
+rust_version = "1.71.0"
 rustup_version = "1.26.0"
 
 DebianArch = namedtuple("DebianArch", ["bashbrew", "dpkg", "rust"])


### PR DESCRIPTION
This bumps the rust version to `1.71.0`

Rust Blog: https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html
Rust Release: https://github.com/rust-lang/rust/releases/tag/1.71.0