### PR TITLE
chore: Add `Muscraft` as a maintainer

### DIFF
--- a/x.py
+++ b/x.py
@@ -148,7 +148,8 @@ def generate_stackbrew_library():
     library = f"""\
 # this file is generated via https://github.com/rust-lang/docker-rust/blob/{commit}/x.py
 
-Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler)
+Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
+             Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 """
 


### PR DESCRIPTION
After talking with @sfackler, it was suggested that I add myself as a maintainer to `x.py` so that I can update the [official image](https://github.com/docker-library/official-images).