### PR TITLE
Revert "feat: Add publishing to ghcr"

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,12 +69,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#      - uses: docker/login-action@v3
+#        if: github.event_name != 'pull_request'
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -87,7 +87,7 @@ jobs:
         with:
           images: |
             rustlang/rust
-            ghcr.io/rust-lang/rust
+#            ghcr.io/rust-lang/rust
           tags: ${{ matrix.tags }}
 
       - uses: docker/build-push-action@v5


### PR DESCRIPTION
This reverts commit 96577a0b83f93cbe1af59e4eaa178b38c37a6ebf. I am doing this because of how we were (and would)       publish to GHCR, which was not the best and ended up not working as I do not have permission to publish.