### PR TITLE
Rename ghcr.io image back to rust-lang/rust

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           images: |
             rustlang/rust
-            ghcr.io/rust-lang/rust-test
+#            ghcr.io/rust-lang/rust
           tags: ${{ matrix.tags }}
 
       - uses: docker/build-push-action@v5


### PR DESCRIPTION
And comment it for now, until we get rid of the old image.