### PR TITLE
Restore publishing to ghcr.io

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           images: |
             rustlang/rust
-#            ghcr.io/rust-lang/rust
+            ghcr.io/rust-lang/rust
           tags: ${{ matrix.tags }}
 
       - uses: docker/build-push-action@v5


### PR DESCRIPTION
This should only be merged after we give access to this repo for the `rust-lang/rust` package.