### PR TITLE
Add Docker LABEL to associate the built images with the `docker-rust` repository.

### DIFF
--- a/1.77.1/alpine3.18/Dockerfile
+++ b/1.77.1/alpine3.18/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.18
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 RUN apk add --no-cache \
         ca-certificates \
         gcc

--- a/1.77.1/alpine3.19/Dockerfile
+++ b/1.77.1/alpine3.19/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.19
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 RUN apk add --no-cache \
         ca-certificates \
         gcc

--- a/1.77.1/bookworm/Dockerfile
+++ b/1.77.1/bookworm/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:bookworm
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/1.77.1/bookworm/slim/Dockerfile
+++ b/1.77.1/bookworm/slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bookworm-slim
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/1.77.1/bullseye/Dockerfile
+++ b/1.77.1/bullseye/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:bullseye
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/1.77.1/bullseye/slim/Dockerfile
+++ b/1.77.1/bullseye/slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bullseye-slim
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/1.77.1/buster/Dockerfile
+++ b/1.77.1/buster/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:buster
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/1.77.1/buster/slim/Dockerfile
+++ b/1.77.1/buster/slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:buster-slim
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,7 @@
 FROM alpine:%%TAG%%
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 RUN apk add --no-cache \
         ca-certificates \
         gcc

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,5 +1,7 @@
 FROM buildpack-deps:%%DEBIAN-SUITE%%
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,5 +1,7 @@
 FROM debian:%%DEBIAN-SUITE%%-slim
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/nightly/alpine3.18/Dockerfile
+++ b/nightly/alpine3.18/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.18
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 RUN apk add --no-cache \
         ca-certificates \
         gcc

--- a/nightly/alpine3.19/Dockerfile
+++ b/nightly/alpine3.19/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.19
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 RUN apk add --no-cache \
         ca-certificates \
         gcc

--- a/nightly/bookworm/Dockerfile
+++ b/nightly/bookworm/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:bookworm
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/nightly/bookworm/slim/Dockerfile
+++ b/nightly/bookworm/slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bookworm-slim
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/nightly/bullseye/Dockerfile
+++ b/nightly/bullseye/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:bullseye
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/nightly/bullseye/slim/Dockerfile
+++ b/nightly/bullseye/slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bullseye-slim
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/nightly/buster/Dockerfile
+++ b/nightly/buster/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:buster
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/nightly/buster/slim/Dockerfile
+++ b/nightly/buster/slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:buster-slim
 
+LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \


### PR DESCRIPTION
Hopefully this could help to re-associate the published packages with this repo.

I executed `x.py update` to update the Dockerfiles.