### PR TITLE
Update Rust version to 1.81.0 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
 #RUST_VERSION
-      RUST_VERSION: 1.80.1
+      RUST_VERSION: 1.81.0
 #RUST_VERSION
     strategy:
       matrix:

--- a/1.81.0/alpine3.19/Dockerfile
+++ b/1.81.0/alpine3.19/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.19
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.80.1
+    RUST_VERSION=1.81.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.81.0/alpine3.20/Dockerfile
+++ b/1.81.0/alpine3.20/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.20
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.80.1
+    RUST_VERSION=1.81.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/1.81.0/bookworm/Dockerfile
+++ b/1.81.0/bookworm/Dockerfile
@@ -1,11 +1,11 @@
-FROM buildpack-deps:bullseye
+FROM buildpack-deps:bookworm
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.80.1
+    RUST_VERSION=1.81.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.81.0/bookworm/slim/Dockerfile
+++ b/1.81.0/bookworm/slim/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.80.1
+    RUST_VERSION=1.81.0
 
 RUN set -eux; \
     apt-get update; \

--- a/1.81.0/bullseye/Dockerfile
+++ b/1.81.0/bullseye/Dockerfile
@@ -1,11 +1,11 @@
-FROM buildpack-deps:bookworm
+FROM buildpack-deps:bullseye
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.80.1
+    RUST_VERSION=1.81.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.81.0/bullseye/slim/Dockerfile
+++ b/1.81.0/bullseye/slim/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.80.1
+    RUST_VERSION=1.81.0
 
 RUN set -eux; \
     apt-get update; \

--- a/x.py
+++ b/x.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-stable_rust_version = "1.80.1"
+stable_rust_version = "1.81.0"
 supported_rust_versions = [stable_rust_version, "nightly"]
 rustup_version = "1.27.1"
 


### PR DESCRIPTION
Rust Version 1.81 has been released!

https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html