### PR TITLE
chore(ci): Revert temporary workaround for ARM builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,10 +61,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        # Temporary workaround for ARM builds
-        # https://github.com/docker/setup-qemu-action/issues/198
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR


### PR DESCRIPTION
reverts #226 as https://github.com/docker/setup-qemu-action/issues/198 has been fixed