### PR TITLE
chore: Bump to rust version 1.85.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
 #RUST_VERSION
-      RUST_VERSION: 1.85.0
+      RUST_VERSION: 1.85.1
 #RUST_VERSION
     strategy:
       matrix:

--- a/stable/alpine3.20/Dockerfile
+++ b/stable/alpine3.20/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0
+    RUST_VERSION=1.85.1
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/stable/alpine3.21/Dockerfile
+++ b/stable/alpine3.21/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0
+    RUST_VERSION=1.85.1
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/stable/bookworm/Dockerfile
+++ b/stable/bookworm/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0
+    RUST_VERSION=1.85.1
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/stable/bookworm/slim/Dockerfile
+++ b/stable/bookworm/slim/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0
+    RUST_VERSION=1.85.1
 
 RUN set -eux; \
     apt-get update; \

--- a/stable/bullseye/Dockerfile
+++ b/stable/bullseye/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0
+    RUST_VERSION=1.85.1
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/stable/bullseye/slim/Dockerfile
+++ b/stable/bullseye/slim/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0
+    RUST_VERSION=1.85.1
 
 RUN set -eux; \
     apt-get update; \

--- a/x.py
+++ b/x.py
@@ -9,7 +9,7 @@ import sys
 rustup_version = "1.28.1"
 
 Channel = namedtuple("Channel", ["name", "rust_version"])
-stable = Channel("stable", "1.85.0")
+stable = Channel("stable", "1.85.1")
 nightly = Channel("nightly", "nightly")
 supported_channels = [
     stable,


### PR DESCRIPTION
https://blog.rust-lang.org/2025/03/18/Rust-1.85.1.html
https://github.com/rust-lang/rust/releases/tag/1.85.1