### PR TITLE
Update license

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2024 The Rust Project Developers
+Copyright (c) The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,4 @@
-MIT License
-
-Copyright (c) The Rust Project Developers
+Copyright (c) The Rust Project Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ An image tracking the Rust nightly toolchain is available via
 
 ## License
 
-Copyright The Rust Project Developers
-
 Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)> or the MIT license
 <LICENSE-MIT or [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)>, at your

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An image tracking the Rust nightly toolchain is available via
 
 ## License
 
-Copyright 2017-2024 The Rust Project Developers
+Copyright The Rust Project Developers
 
 Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)> or the MIT license


### PR DESCRIPTION
This removes the copyright year as well as matches [`rust-lang/rust's LICENSE-MIT`](https://github.com/rust-lang/rust/blob/3c877f6a477380ed61155d3bf816df09c9e05b9e/LICENSE-MIT).