### PR TITLE
Add Alpine ppc64le images

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,17 +55,17 @@ jobs:
               nightly-trixie-slim
           - name: alpine3.20
             context: nightly/alpine3.20
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64,linux/arm64,linux/ppc64le
             tags: |
               nightly-alpine3.20
           - name: alpine3.21
             context: nightly/alpine3.21
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64,linux/arm64,linux/ppc64le
             tags: |
               nightly-alpine3.21
           - name: alpine3.22
             context: nightly/alpine3.22
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64,linux/arm64,linux/ppc64le
             tags: |
               nightly-alpine3.22
               nightly-alpine

--- a/nightly/alpine3.20/Dockerfile
+++ b/nightly/alpine3.20/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
     case "$apkArch" in \
         x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='e6599a1c7be58a2d8eaca66a80e0dc006d87bbcf780a58b7343d6e14c1605cb2' ;; \
         aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='a97c8f56d7462908695348dd8c71ea6740c138ce303715793a690503a94fc9a9' ;; \
+        ppc64le) rustArch='powerpc64le-unknown-linux-musl'; rustupSha256='08423383d36362d93f8d85f208aa5004a7cef77b69b29fb779ba03ed0544e4f1' ;; \
         *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"; \

--- a/nightly/alpine3.21/Dockerfile
+++ b/nightly/alpine3.21/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
     case "$apkArch" in \
         x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='e6599a1c7be58a2d8eaca66a80e0dc006d87bbcf780a58b7343d6e14c1605cb2' ;; \
         aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='a97c8f56d7462908695348dd8c71ea6740c138ce303715793a690503a94fc9a9' ;; \
+        ppc64le) rustArch='powerpc64le-unknown-linux-musl'; rustupSha256='08423383d36362d93f8d85f208aa5004a7cef77b69b29fb779ba03ed0544e4f1' ;; \
         *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"; \

--- a/nightly/alpine3.22/Dockerfile
+++ b/nightly/alpine3.22/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
     case "$apkArch" in \
         x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='e6599a1c7be58a2d8eaca66a80e0dc006d87bbcf780a58b7343d6e14c1605cb2' ;; \
         aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='a97c8f56d7462908695348dd8c71ea6740c138ce303715793a690503a94fc9a9' ;; \
+        ppc64le) rustArch='powerpc64le-unknown-linux-musl'; rustupSha256='08423383d36362d93f8d85f208aa5004a7cef77b69b29fb779ba03ed0544e4f1' ;; \
         *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"; \

--- a/stable/alpine3.20/Dockerfile
+++ b/stable/alpine3.20/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
     case "$apkArch" in \
         x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='e6599a1c7be58a2d8eaca66a80e0dc006d87bbcf780a58b7343d6e14c1605cb2' ;; \
         aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='a97c8f56d7462908695348dd8c71ea6740c138ce303715793a690503a94fc9a9' ;; \
+        ppc64le) rustArch='powerpc64le-unknown-linux-musl'; rustupSha256='08423383d36362d93f8d85f208aa5004a7cef77b69b29fb779ba03ed0544e4f1' ;; \
         *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"; \

--- a/stable/alpine3.21/Dockerfile
+++ b/stable/alpine3.21/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
     case "$apkArch" in \
         x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='e6599a1c7be58a2d8eaca66a80e0dc006d87bbcf780a58b7343d6e14c1605cb2' ;; \
         aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='a97c8f56d7462908695348dd8c71ea6740c138ce303715793a690503a94fc9a9' ;; \
+        ppc64le) rustArch='powerpc64le-unknown-linux-musl'; rustupSha256='08423383d36362d93f8d85f208aa5004a7cef77b69b29fb779ba03ed0544e4f1' ;; \
         *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"; \

--- a/stable/alpine3.22/Dockerfile
+++ b/stable/alpine3.22/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
     case "$apkArch" in \
         x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='e6599a1c7be58a2d8eaca66a80e0dc006d87bbcf780a58b7343d6e14c1605cb2' ;; \
         aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='a97c8f56d7462908695348dd8c71ea6740c138ce303715793a690503a94fc9a9' ;; \
+        ppc64le) rustArch='powerpc64le-unknown-linux-musl'; rustupSha256='08423383d36362d93f8d85f208aa5004a7cef77b69b29fb779ba03ed0544e4f1' ;; \
         *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"; \

--- a/x.py
+++ b/x.py
@@ -45,6 +45,7 @@ AlpineArch = namedtuple("AlpineArch", ["bashbrew", "apk", "qemu", "rust"])
 alpine_arches = [
     AlpineArch("amd64", "x86_64", "linux/amd64", "x86_64-unknown-linux-musl"),
     AlpineArch("arm64v8", "aarch64", "linux/arm64", "aarch64-unknown-linux-musl"),
+    AlpineArch("ppc64le", "ppc64le", "linux/ppc64le", "powerpc64le-unknown-linux-musl"),
 ]
 
 alpine_versions = [


### PR DESCRIPTION
powerpc64le-unknown-linux-musl is a tier 2 with host tools target since 1.85.0, which lets us add support for ppc64le to the Alpine Linux images.