### PR TITLE
chore: Make Trixie the default debian version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,23 +36,23 @@ jobs:
             platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
             tags: |
               nightly-bookworm
-              nightly
           - name: slim-bookworm
             context: nightly/bookworm/slim
             platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
             tags: |
               nightly-bookworm-slim
-              nightly-slim
           - name: trixie
             context: nightly/trixie
             platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
             tags: |
               nightly-trixie
+              nightly
           - name: slim-trixie
             context: nightly/trixie/slim
             platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
             tags: |
               nightly-trixie-slim
+              nightly-slim
           - name: alpine3.20
             context: nightly/alpine3.20
             platforms: linux/amd64,linux/arm64,linux/ppc64le

--- a/x.py
+++ b/x.py
@@ -38,7 +38,7 @@ debian_variants = [
     DebianVariant("trixie", debian_lts_arches + debian_non_lts_arches),
 ]
 
-default_debian_variant = "bookworm"
+default_debian_variant = "trixie"
 
 AlpineArch = namedtuple("AlpineArch", ["bashbrew", "apk", "qemu", "rust"])
 


### PR DESCRIPTION
[Debian Trixie](https://www.debian.org/releases/trixie/) was officially released on `2025-08-09`, making it the newest stable Debian version. Since that is the case, I made it the "default" Debian version.