### PR TITLE
chore: Update Rust version to 1.91.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
 #RUST_VERSION
-      RUST_VERSION: 1.90.0
+      RUST_VERSION: 1.91.0
 #RUST_VERSION
     strategy:
       matrix:

--- a/.github/workflows/mirror_stable.yml
+++ b/.github/workflows/mirror_stable.yml
@@ -22,68 +22,68 @@ jobs:
           - name: alpine3.20
             tags: |
               1-alpine3.20
-              1.90-alpine3.20
-              1.90.0-alpine3.20
+              1.91-alpine3.20
+              1.91.0-alpine3.20
               alpine3.20
           - name: alpine3.21
             tags: |
               1-alpine3.21
-              1.90-alpine3.21
-              1.90.0-alpine3.21
+              1.91-alpine3.21
+              1.91.0-alpine3.21
               alpine3.21
           - name: alpine3.22
             tags: |
               1-alpine3.22
-              1.90-alpine3.22
-              1.90.0-alpine3.22
+              1.91-alpine3.22
+              1.91.0-alpine3.22
               alpine3.22
               1-alpine
-              1.90-alpine
-              1.90.0-alpine
+              1.91-alpine
+              1.91.0-alpine
               alpine
           - name: bullseye
             tags: |
               1-bullseye
-              1.90-bullseye
-              1.90.0-bullseye
+              1.91-bullseye
+              1.91.0-bullseye
               bullseye
           - name: slim-bullseye
             tags: |
               1-slim-bullseye
-              1.90-slim-bullseye
-              1.90.0-slim-bullseye
+              1.91-slim-bullseye
+              1.91.0-slim-bullseye
               slim-bullseye
           - name: bookworm
             tags: |
               1-bookworm
-              1.90-bookworm
-              1.90.0-bookworm
+              1.91-bookworm
+              1.91.0-bookworm
               bookworm
           - name: slim-bookworm
             tags: |
               1-slim-bookworm
-              1.90-slim-bookworm
-              1.90.0-slim-bookworm
+              1.91-slim-bookworm
+              1.91.0-slim-bookworm
               slim-bookworm
           - name: trixie
             tags: |
               1-trixie
-              1.90-trixie
-              1.90.0-trixie
+              1.91-trixie
+              1.91.0-trixie
               trixie
               1
-              1.90
-              1.90.0
+              1.91
+              1.91.0
               latest
           - name: slim-trixie
             tags: |
               1-slim-trixie
-              1.90-slim-trixie
-              1.90.0-slim-trixie
+              1.91-slim-trixie
+              1.91.0-slim-trixie
               slim-trixie
               1-slim
-              1.90-slim
-              1.90.0-slim
+              1.91-slim
+              1.91.0-slim
               slim
 #VERSIONS
     steps:

--- a/stable/alpine3.20/Dockerfile
+++ b/stable/alpine3.20/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/stable/alpine3.21/Dockerfile
+++ b/stable/alpine3.21/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/stable/alpine3.22/Dockerfile
+++ b/stable/alpine3.22/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/stable/bookworm/Dockerfile
+++ b/stable/bookworm/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/stable/bookworm/slim/Dockerfile
+++ b/stable/bookworm/slim/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/stable/bullseye/Dockerfile
+++ b/stable/bullseye/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/stable/bullseye/slim/Dockerfile
+++ b/stable/bullseye/slim/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/stable/trixie/Dockerfile
+++ b/stable/trixie/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/stable/trixie/slim/Dockerfile
+++ b/stable/trixie/slim/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.90.0
+    RUST_VERSION=1.91.0
 
 RUN set -eux; \
     \

--- a/x.py
+++ b/x.py
@@ -9,7 +9,7 @@ import sys
 rustup_version = "1.28.2"
 
 Channel = namedtuple("Channel", ["name", "rust_version"])
-stable = Channel("stable", "1.90.0")
+stable = Channel("stable", "1.91.0")
 nightly = Channel("nightly", "nightly")
 supported_channels = [
     stable,


### PR DESCRIPTION
https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/
https://github.com/rust-lang/rust/releases/tag/1.91.0