### PR TITLE
Tag nightly versions with date

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'
 
@@ -80,7 +81,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
         uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
         with:
           registry: ghcr.io
           username: rust-lang
@@ -88,7 +89,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
         with:
           username: rustopsbot
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -128,8 +129,8 @@ jobs:
         with:
           context: ${{ matrix.context }}
           platforms: ${{ matrix.platforms }}
-          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             RUST_VERSION=nightly-${{ steps.date.outputs.date }}
+          push: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 6 * * *'
 
 jobs:
   build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,7 +96,25 @@ jobs:
 
       - name: Compute nightly date
         id: date
-        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+          URL="https://static.rust-lang.org/dist/${DATE}/channel-rust-nightly.toml"
+          if ! curl -fsI -o /dev/null "$URL"; then
+            case "${EVENT_NAME}" in
+              push|pull_request)
+                echo "Today's nightly manifest is not yet published; falling back to yesterday." >&2
+                DATE=$(date -u -d 'yesterday' +%Y-%m-%d)
+                ;;
+              *)
+                echo "Today's nightly manifest is not yet published; refusing to publish a stale nightly." >&2
+                exit 1
+                ;;
+            esac
+          fi
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Build dated tag list
         id: dated_tags

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,6 +93,25 @@ jobs:
           username: rustopsbot
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Compute nightly date
+        id: date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Build dated tag list
+        id: dated_tags
+        env:
+          BASE_TAGS: ${{ matrix.tags }}
+          DATE: ${{ steps.date.outputs.date }}
+        run: |
+          {
+            echo "tags<<EOF"
+            while IFS= read -r tag; do
+              [ -z "$tag" ] && continue
+              echo "type=raw,value=${tag}-${DATE}"
+            done <<< "$BASE_TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -100,7 +119,9 @@ jobs:
           images: |
             rustlang/rust
             ghcr.io/rust-lang/rust
-          tags: ${{ matrix.tags }}
+          tags: |
+            ${{ matrix.tags }}
+            ${{ steps.dated_tags.outputs.tags }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6
@@ -108,5 +129,7 @@ jobs:
           context: ${{ matrix.context }}
           platforms: ${{ matrix.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            RUST_VERSION=nightly-${{ steps.date.outputs.date }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,10 +7,11 @@ RUN apk add --no-cache \
         musl-dev \
         gcc
 
+%%RUST-VERSION-ARG%%
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=%%RUST-VERSION%%
+    RUST_VERSION=%%RUST-VERSION-VALUE%%
 
 RUN set -eux; \
     \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -2,10 +2,11 @@ FROM buildpack-deps:%%TAG%%
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
+%%RUST-VERSION-ARG%%
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=%%RUST-VERSION%%
+    RUST_VERSION=%%RUST-VERSION-VALUE%%
 
 RUN set -eux; \
     \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -2,10 +2,11 @@ FROM debian:%%TAG%%-slim
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
+%%RUST-VERSION-ARG%%
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=%%RUST-VERSION%%
+    RUST_VERSION=%%RUST-VERSION-VALUE%%
 
 RUN set -eux; \
     \

--- a/nightly/alpine3.21/Dockerfile
+++ b/nightly/alpine3.21/Dockerfile
@@ -7,10 +7,11 @@ RUN apk add --no-cache \
         musl-dev \
         gcc
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/nightly/alpine3.22/Dockerfile
+++ b/nightly/alpine3.22/Dockerfile
@@ -7,10 +7,11 @@ RUN apk add --no-cache \
         musl-dev \
         gcc
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/nightly/alpine3.23/Dockerfile
+++ b/nightly/alpine3.23/Dockerfile
@@ -7,10 +7,11 @@ RUN apk add --no-cache \
         musl-dev \
         gcc
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/nightly/bookworm/Dockerfile
+++ b/nightly/bookworm/Dockerfile
@@ -2,10 +2,11 @@ FROM buildpack-deps:bookworm
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/nightly/bookworm/slim/Dockerfile
+++ b/nightly/bookworm/slim/Dockerfile
@@ -2,10 +2,11 @@ FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/nightly/bullseye/Dockerfile
+++ b/nightly/bullseye/Dockerfile
@@ -2,10 +2,11 @@ FROM buildpack-deps:bullseye
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/nightly/bullseye/slim/Dockerfile
+++ b/nightly/bullseye/slim/Dockerfile
@@ -2,10 +2,11 @@ FROM debian:bullseye-slim
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/nightly/trixie/Dockerfile
+++ b/nightly/trixie/Dockerfile
@@ -2,10 +2,11 @@ FROM buildpack-deps:trixie
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/nightly/trixie/slim/Dockerfile
+++ b/nightly/trixie/slim/Dockerfile
@@ -2,10 +2,11 @@ FROM debian:trixie-slim
 
 LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
 
+ARG RUST_VERSION=nightly
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
+    RUST_VERSION=${RUST_VERSION}
 
 RUN set -eux; \
     \

--- a/x.py
+++ b/x.py
@@ -157,11 +157,13 @@ def render_template(
     rendered_path
 ):
     template = read_file(template_path)
-    rendered = template \
-        .replace("%%TAG%%", docker_tag) \
-        .replace("%%RUST-VERSION%%", rust_version) \
-        .replace("%%RUSTUP-VERSION%%", rustup_version) \
+    rendered = (
+        template
+        .replace("%%TAG%%", docker_tag)
+        .replace("%%RUST-VERSION%%", rust_version)
+        .replace("%%RUSTUP-VERSION%%", rustup_version)
         .replace("%%ARCH-CASE%%", arch_cases)
+    )
     write_file(rendered_path, rendered)
 
 def update_ci():

--- a/x.py
+++ b/x.py
@@ -156,11 +156,20 @@ def render_template(
     arch_cases,
     rendered_path
 ):
+    if rust_version == "nightly":
+        rust_version_arg = "ARG RUST_VERSION=nightly\n"
+        rust_version_value = "${RUST_VERSION}"
+    else:
+        rust_version_arg = ""
+        rust_version_value = rust_version
+
     template = read_file(template_path)
     rendered = (
         template
         .replace("%%TAG%%", docker_tag)
-        .replace("%%RUST-VERSION%%", rust_version)
+        # We match with `\n` here so that the line is removed entirely if the argument is not needed
+        .replace("%%RUST-VERSION-ARG%%\n", rust_version_arg)
+        .replace("%%RUST-VERSION-VALUE%%", rust_version_value)
         .replace("%%RUSTUP-VERSION%%", rustup_version)
         .replace("%%ARCH-CASE%%", arch_cases)
     )


### PR DESCRIPTION
Tagging the nightly images with the date has been requested in the past (rust-lang/docker-rust-nightly#3, #177, [#general > docker nightly pinned](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/docker.20nightly.20pinned/with/595837208)), and after looking at it again, I think it would make sense to support it. The biggest concern is the large number of additional tags this would add (~4000), but it does not appear to be an issue for GHCR or Docker Hub. I looked into the limits for both services, and neither mentioned an upper limit on tags. On Docker Hub, `instrumentisto/rust` used to tag Rust's nightly images for some time before it was recently archived.

@sfackler
@Kobzol