### PR TITLE
Update and pin Github Action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 #VERSIONS
     name: ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
       - run: git clone https://github.com/docker-library/official-images.git ~/official-images
       - run: docker build -t rust:$RUST_VERSION-${{ matrix.name }} stable/${{ matrix.variant }}
       - run: ~/official-images/test/run.sh rust:$RUST_VERSION-${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 #VERSIONS
     name: ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: git clone https://github.com/docker-library/official-images.git ~/official-images
       - run: docker build -t rust:$RUST_VERSION-${{ matrix.name }} stable/${{ matrix.variant }}
       - run: ~/official-images/test/run.sh rust:$RUST_VERSION-${{ matrix.name }}

--- a/.github/workflows/mirror_stable.yml
+++ b/.github/workflows/mirror_stable.yml
@@ -87,7 +87,7 @@ jobs:
               slim
 #VERSIONS
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/mirror_stable.yml
+++ b/.github/workflows/mirror_stable.yml
@@ -92,13 +92,13 @@ jobs:
           persist-credentials: false
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         with:
           username: rustopsbot
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/mirror_stable.yml
+++ b/.github/workflows/mirror_stable.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   mirror:
     name: DockerHub mirror
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: github.repository == 'rust-lang/docker-rust'
     permissions:
       contents: read

--- a/.github/workflows/mirror_stable.yml
+++ b/.github/workflows/mirror_stable.yml
@@ -87,18 +87,18 @@ jobs:
               slim
 #VERSIONS
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: rustopsbot
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       
       - name: Login to GHCR
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,13 +74,13 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to GHCR
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
         with:
           registry: ghcr.io
@@ -88,7 +88,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
         with:
           username: rustopsbot
@@ -133,7 +133,7 @@ jobs:
 
       - name: Docker Metadata
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             rustlang/rust
@@ -143,7 +143,7 @@ jobs:
             ${{ steps.dated_tags.outputs.tags }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ matrix.context }}
           platforms: ${{ matrix.platforms }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
         with:
           registry: ghcr.io
@@ -88,7 +88,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
         with:
           username: rustopsbot

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Docker Metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6.1.0
         with:
           images: |
             rustlang/rust

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4.1.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.1.0
       - name: Login to GHCR
         uses: docker/login-action@v4.2.0
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -143,7 +143,7 @@ jobs:
             ${{ steps.dated_tags.outputs.tags }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.2.0
         with:
           context: ${{ matrix.context }}
           platforms: ${{ matrix.platforms }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,7 +74,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
While looking at the CI workflow file, I noticed that the `actions/checkout` action was out of date, so I decided to update the version for all actions. As part of this, I also pinned the actions to a SHA, as it will make it easier to add a CI job for Zizmor in the future.