### PR TITLE
Remove s390x from Debian Bookworm

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,12 +34,12 @@ jobs:
               nightly-bullseye-slim
           - name: bookworm
             context: nightly/bookworm
-            platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
+            platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le
             tags: |
               nightly-bookworm
           - name: slim-bookworm
             context: nightly/bookworm/slim
-            platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
+            platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le
             tags: |
               nightly-bookworm-slim
           - name: trixie

--- a/nightly/bookworm/Dockerfile
+++ b/nightly/bookworm/Dockerfile
@@ -32,10 +32,6 @@ RUN set -eux; \
             rustArch='powerpc64le-unknown-linux-gnu'; \
             rustupSha256='4bfff85bd3967d988e14567aa9cc6ab0ea386f0ffeff0f9f14d23f0103bf1f97'; \
             ;; \
-        's390x') \
-            rustArch='s390x-unknown-linux-gnu'; \
-            rustupSha256='66c2c132428b6b77803facb02cbdf33b89d20c00bd20da142be8cb651f2e7cd8'; \
-            ;; \
         *) \
             echo >&2 "unsupported architecture: $arch"; \
             exit 1; \

--- a/nightly/bookworm/slim/Dockerfile
+++ b/nightly/bookworm/slim/Dockerfile
@@ -40,10 +40,6 @@ RUN set -eux; \
             rustArch='powerpc64le-unknown-linux-gnu'; \
             rustupSha256='4bfff85bd3967d988e14567aa9cc6ab0ea386f0ffeff0f9f14d23f0103bf1f97'; \
             ;; \
-        's390x') \
-            rustArch='s390x-unknown-linux-gnu'; \
-            rustupSha256='66c2c132428b6b77803facb02cbdf33b89d20c00bd20da142be8cb651f2e7cd8'; \
-            ;; \
         *) \
             echo >&2 "unsupported architecture: $arch"; \
             exit 1; \

--- a/stable/bookworm/Dockerfile
+++ b/stable/bookworm/Dockerfile
@@ -31,10 +31,6 @@ RUN set -eux; \
             rustArch='powerpc64le-unknown-linux-gnu'; \
             rustupSha256='4bfff85bd3967d988e14567aa9cc6ab0ea386f0ffeff0f9f14d23f0103bf1f97'; \
             ;; \
-        's390x') \
-            rustArch='s390x-unknown-linux-gnu'; \
-            rustupSha256='66c2c132428b6b77803facb02cbdf33b89d20c00bd20da142be8cb651f2e7cd8'; \
-            ;; \
         *) \
             echo >&2 "unsupported architecture: $arch"; \
             exit 1; \

--- a/stable/bookworm/slim/Dockerfile
+++ b/stable/bookworm/slim/Dockerfile
@@ -39,10 +39,6 @@ RUN set -eux; \
             rustArch='powerpc64le-unknown-linux-gnu'; \
             rustupSha256='4bfff85bd3967d988e14567aa9cc6ab0ea386f0ffeff0f9f14d23f0103bf1f97'; \
             ;; \
-        's390x') \
-            rustArch='s390x-unknown-linux-gnu'; \
-            rustupSha256='66c2c132428b6b77803facb02cbdf33b89d20c00bd20da142be8cb651f2e7cd8'; \
-            ;; \
         *) \
             echo >&2 "unsupported architecture: $arch"; \
             exit 1; \

--- a/x.py
+++ b/x.py
@@ -346,11 +346,11 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
                 tags.append(version_tag)
             tags.append("latest")
 
-        arches = release.arches[:]
+        bashbrews = [a.bashbrew for a in release.arches]
 
         library += single_library(
                 tags,
-                map(lambda a: a.bashbrew, arches),
+                bashbrews,
                 os.path.join(stable.name, release.name))
 
         tags = []
@@ -364,7 +364,7 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
 
         library += single_library(
                 tags,
-                map(lambda a: a.bashbrew, arches),
+                bashbrews,
                 os.path.join(stable.name, release.name, "slim"))
 
     for version in alpine_versions:
@@ -379,7 +379,7 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
 
         library += single_library(
             tags,
-            map(lambda a: a.bashbrew, alpine_arches),
+            [a.bashbrew for a in alpine_arches],
             os.path.join(stable.name, f"alpine{version}"))
 
     print(library)

--- a/x.py
+++ b/x.py
@@ -42,26 +42,30 @@ debian_arches = {
 }
 
 debian_lts_arches = [
-    debian_arches["amd64"],
-    debian_arches["arm32v7"],
-    debian_arches["arm64v8"],
-    debian_arches["i386"],
+    "amd64",
+    "arm32v7",
+    "arm64v8",
+    "i386",
 ]
 
 debian_non_lts_arches = [
-    debian_arches["ppc64le"],
-    debian_arches["s390x"],
+    "ppc64le",
+    "s390x",
 ]
 
 debian_trixie_arches = [
-    debian_arches["riscv64"],
+    "riscv64",
 ]
 
 class DebianRelease(NamedTuple):
     name: str
-    arches: list[DebianArch]
+    arch_names: list[str]
     is_latest: bool = False
- 
+
+    @property
+    def arches(self) -> list[DebianArch]:
+        return [debian_arches[name] for name in self.arch_names]
+
 debian_releases = [
     DebianRelease("bullseye", debian_lts_arches),
     DebianRelease("bookworm", debian_lts_arches + debian_non_lts_arches),

--- a/x.py
+++ b/x.py
@@ -52,7 +52,7 @@ class DebianRelease(NamedTuple):
 
 debian_releases = [
     DebianRelease("bullseye", ["amd64", "arm32v7", "arm64v8", "i386"]),
-    DebianRelease("bookworm", ["amd64", "arm32v7", "arm64v8", "i386", "ppc64le", "s390x"]),
+    DebianRelease("bookworm", ["amd64", "arm32v7", "arm64v8", "i386", "ppc64le"]),
     DebianRelease("trixie", ["amd64", "arm32v7", "arm64v8", "i386", "ppc64le", "s390x", "riscv64"], is_latest=True),
 ]
 

--- a/x.py
+++ b/x.py
@@ -2,6 +2,7 @@
 
 import argparse
 from collections import namedtuple
+from typing import NamedTuple
 from urllib import request
 import os
 import subprocess
@@ -48,7 +49,9 @@ debian_trixie_arches = [
 
 latest_debian_release = "trixie"
 
-DebianRelease = namedtuple("DebianRelease", ["name", "arches"])
+class DebianRelease(NamedTuple):
+    name: str
+    arches: list[DebianArch]
  
 debian_releases = [
     DebianRelease("bullseye", debian_lts_arches),

--- a/x.py
+++ b/x.py
@@ -262,10 +262,7 @@ def update_nightly_ci():
 
     versions = ""
     for release in debian_releases:
-        platforms = []
-        for arch in release.arches:
-            platforms.append(f"{arch.qemu}")
-        platforms = ",".join(platforms)
+        platforms = ",".join(arch.qemu for arch in release.arches)
 
         tags = [f"nightly-{release.name}"]
         if release.name == latest_debian_release:
@@ -286,10 +283,7 @@ def update_nightly_ci():
             versions += f"              {tag}-slim\n"
 
     for version in alpine_versions:
-        platforms = []
-        for arch in alpine_arches:
-            platforms.append(f"{arch.qemu}")
-        platforms = ",".join(platforms)
+        platforms = ",".join(arch.qemu for arch in alpine_arches)
 
         tags = [f"nightly-alpine{version}"]
         if version == latest_alpine_version:

--- a/x.py
+++ b/x.py
@@ -31,20 +31,30 @@ supported_channels = [
 
 DebianArch = namedtuple("DebianArch", ["bashbrew", "dpkg", "qemu", "rust"])
 
+debian_arches = {
+    "amd64": DebianArch("amd64", "amd64", "linux/amd64", "x86_64-unknown-linux-gnu"),
+    "arm32v7": DebianArch("arm32v7", "armhf", "linux/arm/v7", "armv7-unknown-linux-gnueabihf"),
+    "arm64v8": DebianArch("arm64v8", "arm64", "linux/arm64", "aarch64-unknown-linux-gnu"),
+    "i386": DebianArch("i386", "i386", "linux/386", "i686-unknown-linux-gnu"),
+    "ppc64le": DebianArch("ppc64le", "ppc64el", "linux/ppc64le", "powerpc64le-unknown-linux-gnu"),
+    "riscv64": DebianArch("riscv64", "riscv64", "linux/riscv64", "riscv64gc-unknown-linux-gnu"),
+    "s390x": DebianArch("s390x", "s390x", "linux/s390x", "s390x-unknown-linux-gnu"),
+}
+
 debian_lts_arches = [
-    DebianArch("amd64", "amd64", "linux/amd64", "x86_64-unknown-linux-gnu"),
-    DebianArch("arm32v7", "armhf", "linux/arm/v7", "armv7-unknown-linux-gnueabihf"),
-    DebianArch("arm64v8", "arm64", "linux/arm64", "aarch64-unknown-linux-gnu"),
-    DebianArch("i386", "i386", "linux/386", "i686-unknown-linux-gnu"),
+    debian_arches["amd64"],
+    debian_arches["arm32v7"],
+    debian_arches["arm64v8"],
+    debian_arches["i386"],
 ]
 
 debian_non_lts_arches = [
-    DebianArch("ppc64le", "ppc64el", "linux/ppc64le", "powerpc64le-unknown-linux-gnu"),
-    DebianArch("s390x", "s390x", "linux/s390x", "s390x-unknown-linux-gnu"),
+    debian_arches["ppc64le"],
+    debian_arches["s390x"],
 ]
 
 debian_trixie_arches = [
-    DebianArch("riscv64", "riscv64", "linux/riscv64", "riscv64gc-unknown-linux-gnu"),
+    debian_arches["riscv64"],
 ]
 
 class DebianRelease(NamedTuple):

--- a/x.py
+++ b/x.py
@@ -47,16 +47,15 @@ debian_trixie_arches = [
     DebianArch("riscv64", "riscv64", "linux/riscv64", "riscv64gc-unknown-linux-gnu"),
 ]
 
-latest_debian_release = "trixie"
-
 class DebianRelease(NamedTuple):
     name: str
     arches: list[DebianArch]
+    is_latest: bool = False
  
 debian_releases = [
     DebianRelease("bullseye", debian_lts_arches),
     DebianRelease("bookworm", debian_lts_arches + debian_non_lts_arches),
-    DebianRelease(latest_debian_release, debian_lts_arches + debian_non_lts_arches + debian_trixie_arches),
+    DebianRelease("trixie", debian_lts_arches + debian_non_lts_arches + debian_trixie_arches, is_latest=True),
 ]
 
 AlpineArch = namedtuple("AlpineArch", ["bashbrew", "apk", "qemu", "rust"])
@@ -228,7 +227,7 @@ def update_mirror_stable_ci():
         for version_tag in version_tags():
             tags.append(f"{version_tag}-{release.name}")
         tags.append(release.name)
-        if release.name == latest_debian_release:
+        if release.is_latest:
             for version_tag in version_tags():
                 tags.append(version_tag)
             tags.append("latest")
@@ -242,7 +241,7 @@ def update_mirror_stable_ci():
         for version_tag in version_tags():
             tags.append(f"{version_tag}-slim-{release.name}")
         tags.append(f"slim-{release.name}")
-        if release.name == latest_debian_release:
+        if release.is_latest:
             for version_tag in version_tags():
                 tags.append(f"{version_tag}-slim")
             tags.append("slim")
@@ -268,7 +267,7 @@ def update_nightly_ci():
         platforms = ",".join(arch.qemu for arch in release.arches)
 
         tags = [f"nightly-{release.name}"]
-        if release.name == latest_debian_release:
+        if release.is_latest:
             tags.append("nightly")
 
         versions += f"          - name: {release.name}\n"
@@ -344,7 +343,7 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
         for version_tag in version_tags():
             tags.append(f"{version_tag}-{release.name}")
         tags.append(release.name)
-        if release.name == latest_debian_release:
+        if release.is_latest:
             for version_tag in version_tags():
                 tags.append(version_tag)
             tags.append("latest")
@@ -360,7 +359,7 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
         for version_tag in version_tags():
             tags.append(f"{version_tag}-slim-{release.name}")
         tags.append(f"slim-{release.name}")
-        if release.name == latest_debian_release:
+        if release.is_latest:
             for version_tag in version_tags():
                 tags.append(f"{version_tag}-slim")
             tags.append("slim")

--- a/x.py
+++ b/x.py
@@ -41,22 +41,6 @@ debian_arches = {
     "s390x": DebianArch("s390x", "s390x", "linux/s390x", "s390x-unknown-linux-gnu"),
 }
 
-debian_lts_arches = [
-    "amd64",
-    "arm32v7",
-    "arm64v8",
-    "i386",
-]
-
-debian_non_lts_arches = [
-    "ppc64le",
-    "s390x",
-]
-
-debian_trixie_arches = [
-    "riscv64",
-]
-
 class DebianRelease(NamedTuple):
     name: str
     arch_names: list[str]
@@ -67,9 +51,9 @@ class DebianRelease(NamedTuple):
         return [debian_arches[name] for name in self.arch_names]
 
 debian_releases = [
-    DebianRelease("bullseye", debian_lts_arches),
-    DebianRelease("bookworm", debian_lts_arches + debian_non_lts_arches),
-    DebianRelease("trixie", debian_lts_arches + debian_non_lts_arches + debian_trixie_arches, is_latest=True),
+    DebianRelease("bullseye", ["amd64", "arm32v7", "arm64v8", "i386"]),
+    DebianRelease("bookworm", ["amd64", "arm32v7", "arm64v8", "i386", "ppc64le", "s390x"]),
+    DebianRelease("trixie", ["amd64", "arm32v7", "arm64v8", "i386", "ppc64le", "s390x", "riscv64"], is_latest=True),
 ]
 
 AlpineArch = namedtuple("AlpineArch", ["bashbrew", "apk", "qemu", "rust"])


### PR DESCRIPTION
This PR removes support for `s390x` from Debian Bookwork as it is [no longer listed as a supported arch of Debian Bookwork](https://wiki.debian.org/LTS/Bookworm).

Orginally reported in [docker-library/official-images#21977 (comment)](https://github.com/docker-library/official-images/pull/21977#issuecomment-5172421111)